### PR TITLE
Make hardware reservation expiry independent of reserving user

### DIFF
--- a/src/controllers/hardwareController.ts
+++ b/src/controllers/hardwareController.ts
@@ -143,7 +143,7 @@ export class HardwareController {
     // otherwise, return that the item can't be reserved
     try {
       const { item, quantity } = req.body;
-      if (isNaN(quantity) || Number(quantity) < 0) {
+      if (isNaN(quantity) || Number(quantity) < 1) {
         return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Invalid quantity provided!"));
       }
       const token: string = await reserveItem(req.user, item, quantity);

--- a/src/public/js/hardware.js
+++ b/src/public/js/hardware.js
@@ -31,7 +31,7 @@ var takenItemUI = '<div><b>You have taken:</b>#reservedQuantity.</div>'
 
 var takeItemUI = '<div><span><b>Quantity to take:</b></span>'
                + '<input type="number" name="quantity" id="#itemId-reservation-quantity"'
-               + 'class="number-input" placeholder="quantity" value="1"></div>'
+               + 'class="number-input" placeholder="quantity" value="1" min="1"></div>'
                + '<button type="button" class="btn btn-success btn-compact" data-dismiss="modal"'
                + 'onclick="reserve(#itemId)">TAKE</button>';
 

--- a/src/util/hardwareLibrary/hardwareItemToken.ts
+++ b/src/util/hardwareLibrary/hardwareItemToken.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import { ReservedHardwareItem } from "../../db/entity/hub";
-import { getConnection } from "typeorm";
+import { getConnection, EntityManager, Repository } from "typeorm";
 
 /**
  * Generates a random token for the hardware item reservation
@@ -13,10 +13,10 @@ export const createToken = (): string => {
  * Gets the user and hardware item that the reservation token is linked to
  * @param resToken Unique reservation token for the user reserved hardware item
  */
-export const parseToken = async (resToken: string): Promise<ReservedHardwareItem> => {
+export const parseToken = async (resToken: string, transaction?: EntityManager): Promise<ReservedHardwareItem> => {
   let reservation: ReservedHardwareItem = undefined;
   try {
-    reservation = await getConnection("hub")
+    reservation = await (transaction ? transaction : getConnection("hub"))
     .getRepository(ReservedHardwareItem)
     .createQueryBuilder("reservation")
     .innerJoin("reservation.user", "user")

--- a/src/util/hardwareLibrary/hardwareItemValidation.ts
+++ b/src/util/hardwareLibrary/hardwareItemValidation.ts
@@ -52,8 +52,9 @@ export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem, r
     // Sets the reservation expiry to be current time + 30 minutes
     newItemReservation.reservationExpiry = new Date(new Date().getTime() + (1000 * 60 * 30));
 
+    await getConnection("hub").transaction(async transaction => {
     // Insert the reservation into the database
-    await getConnection("hub")
+    await transaction
       .createQueryBuilder()
       .insert()
       .into(ReservedHardwareItem)
@@ -61,9 +62,10 @@ export const reserveItemQuery = async (user: User, hardwareItem: HardwareItem, r
       .execute();
 
     // Increment the reservation count for the hardware item
-    await getConnection("hub")
+    await transaction
       .getRepository(HardwareItem)
       .increment({ id: hardwareItem.id }, "reservedStock", requestedQuantity);
+    });
 
     return newItemReservation.reservationToken;
   } catch (err) {
@@ -159,26 +161,28 @@ const isReservationValid = (expiryDate: Date): boolean => {
 export const itemToBeTakenFromLibrary = async (userID: number, hardwareItemID: number, itemQuantity: number): Promise<void> => {
   // The item is reserved and we mark the item as taken
   try {
-    await getConnection("hub")
-      .createQueryBuilder()
-      .update(ReservedHardwareItem)
-      .set({ isReserved: 0 })
-      .where("userId = :uid", { uid: userID })
-      .andWhere("hardwareItemId = :hid", { hid: hardwareItemID })
-      .execute();
+    await getConnection("hub").transaction(async transaction => {
+      await transaction
+        .createQueryBuilder()
+        .update(ReservedHardwareItem)
+        .set({ isReserved: 0 })
+        .where("userId = :uid", { uid: userID })
+        .andWhere("hardwareItemId = :hid", { hid: hardwareItemID })
+        .execute();
 
-    await getConnection("hub")
-      .createQueryBuilder()
-      .update(HardwareItem)
-      .set({
-        takenStock: () => `takenStock + ${itemQuantity}`,
-        reservedStock: () => `reservedStock - ${itemQuantity}`
-      })
-      .where("id = :id", { id: hardwareItemID })
-      .execute();
+      await transaction
+        .createQueryBuilder()
+        .update(HardwareItem)
+        .set({
+          takenStock: () => `takenStock + ${itemQuantity}`,
+          reservedStock: () => `reservedStock - ${itemQuantity}`
+        })
+        .where("id = :id", { id: hardwareItemID })
+        .execute();
 
-      const message: string = `UID ${userID} took ${itemQuantity} of ${hardwareItemID}`;
-      new QueryLogger().hardwareLog(LoggerLevels.LOG, message);
+        const message: string = `UID ${userID} took ${itemQuantity} of ${hardwareItemID}`;
+        new QueryLogger().hardwareLog(LoggerLevels.LOG, message);
+    });
   } catch (err) {
     throw new Error(`Lost connection to database (hub)! ${err}`);
   }
@@ -225,7 +229,7 @@ export const getAllHardwareItemsWithReservations = async (): Promise<HardwareIte
         .getMany();
 
   return items;
-}
+};
 
 /**
  * Returns all the hardware items from the database in a formatted array
@@ -237,17 +241,17 @@ export const getAllHardwareItems = async (userId?: number): Promise<Object[]> =>
     .orderBy("name", "ASC")
     .getMany();
 
-  const userReservations: ReservedHardwareItem[] = await getConnection("hub")
+  const allUserReservations: ReservedHardwareItem[] = await getConnection("hub")
     .getRepository(ReservedHardwareItem)
     .createQueryBuilder("reservation")
     .leftJoinAndSelect("reservation.hardwareItem", "hardwareItem")
-    .where("userId = :userId", { userId })
     .getMany();
 
   const formattedData = [];
   for (const item of hardwareItems) {
     let remainingItemCount: number = item.totalStock - (item.reservedStock + item.takenStock);
-    let reservationForItem = userReservations.find(reservation => reservation.hardwareItem.name === item.name);
+    let reservationForItem: ReservedHardwareItem = allUserReservations.find((reservation) =>
+      reservation.hardwareItem.name === item.name);
 
     if (reservationForItem && reservationForItem.isReserved && !isReservationValid(reservationForItem.reservationExpiry)) {
       remainingItemCount += reservationForItem.reservationQuantity;
@@ -330,7 +334,7 @@ export const deleteHardwareItem = async(id: number): Promise<void> => {
     .from(HardwareItem)
     .where("id = :itemId", { itemId })
     .execute();
-}
+};
 
 export const getAllReservations = async (): Promise<ReservedHardwareItem[]> => {
   try {
@@ -377,42 +381,46 @@ export const cancelReservation = async (token: string, userId: number): Promise<
   if (!reservation.isReserved) {
     throw new ApiError(HttpResponseCode.BAD_REQUEST, "This reservation cannot be cancelled!");
   }
-  const response = await getConnection("hub")
-    .createQueryBuilder()
-    .delete()
-    .from(ReservedHardwareItem)
-    .where("reservationToken = :token", { token })
-    .execute();
-  if (response.raw.affectedRows != 1) {
-    await getConnection("hub")
-      .getRepository(ReservedHardwareItem)
-      .save(reservation);
-    throw new ApiError(HttpResponseCode.INTERNAL_ERROR, "Could not cancel reservation, please inform us that this error occured.");
-  } else {
-    reservation.hardwareItem.reservedStock -= reservation.reservationQuantity;
-    await getConnection("hub")
-      .getRepository(HardwareItem)
-      .save(reservation.hardwareItem);
-  }
+  await getConnection("hub").transaction(async transaction => {
+    const response = await transaction
+      .createQueryBuilder()
+      .delete()
+      .from(ReservedHardwareItem)
+      .where("reservationToken = :token", { token })
+      .execute();
+    if (response.raw.affectedRows != 1) {
+      await transaction
+        .getRepository(ReservedHardwareItem)
+        .save(reservation);
+      throw new ApiError(HttpResponseCode.INTERNAL_ERROR, "Could not cancel reservation, please inform us that this error occured.");
+    } else {
+      reservation.hardwareItem.reservedStock -= reservation.reservationQuantity;
+      await transaction
+        .getRepository(HardwareItem)
+        .save(reservation.hardwareItem);
+    }
+  });
 };
 
 export const deleteReservation = async (tokenToDelete: string): Promise<void> => {
   try {
-    const reservation: ReservedHardwareItem = await parseToken(tokenToDelete);
-    const itemID: number = reservation.hardwareItem.id,
-      itemQuantity: number = reservation.reservationQuantity;
+    await getConnection("hub").transaction(async transaction => {
+      const reservation: ReservedHardwareItem = await parseToken(tokenToDelete, transaction);
+      const itemID: number = reservation.hardwareItem.id,
+        itemQuantity: number = reservation.reservationQuantity;
 
-    await getConnection("hub")
-      .createQueryBuilder()
-      .delete()
-      .from(ReservedHardwareItem)
-      .where("reservationToken = :token", { token: tokenToDelete })
-      .execute();
+      await transaction
+        .createQueryBuilder()
+        .delete()
+        .from(ReservedHardwareItem)
+        .where("reservationToken = :token", { token: tokenToDelete })
+        .execute();
 
-    // Decrement the reservation count for the hardware item
-    await getConnection("hub")
-      .getRepository(HardwareItem)
-      .decrement({ id: itemID }, "reservedStock", itemQuantity);
+      // Decrement the reservation count for the hardware item
+      await transaction
+        .getRepository(HardwareItem)
+        .decrement({ id: itemID }, "reservedStock", itemQuantity);
+    });
 
   } catch (err) {
     throw new Error(`Lost connection to database (hub)! ${err}`);


### PR DESCRIPTION
For issue #85 

- Added some transactions for sql queries that take multiple steps

- When any user loads the hardware library, check for expired reservations

- Ensure that at a minimum, one item can be taken at a time
