### PR TITLE
Set test env settings, make independent of .env

### DIFF
--- a/test/e2e/controllers/hardwareController.test.ts
+++ b/test/e2e/controllers/hardwareController.test.ts
@@ -4,7 +4,7 @@ import { User, HardwareItem, ReservedHardwareItem, Team } from "../../../src/db/
 import { getConnection } from "typeorm";
 import * as request from "supertest";
 import { HttpResponseCode } from "../../../src/util/errorHandling/httpResponseCode";
-import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection } from "../../util/testUtils";
+import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection, initEnv } from "../../util/testUtils";
 import { AuthLevels } from "../../../src/util/user";
 
 let bApp: Express;
@@ -48,6 +48,7 @@ itemReservation.reservationExpiry = new Date(new Date().getTime() + (10000 * 60)
  * Preparing for the tests
  */
 beforeAll(async (done: jest.DoneCallback): Promise<void> => {
+  initEnv();
   buildApp(async (builtApp: Express, err: Error): Promise<void> => {
     if (err) {
       throw new Error("Failed to setup test");

--- a/test/e2e/controllers/userController.test.ts
+++ b/test/e2e/controllers/userController.test.ts
@@ -4,7 +4,7 @@ import { User } from "../../../src/db/entity/hub";
 import { getConnection } from "typeorm";
 import * as request from "supertest";
 import { HttpResponseCode } from "../../../src/util/errorHandling";
-import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection } from "../../util/testUtils";
+import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection, initEnv } from "../../util/testUtils";
 import { AuthLevels } from "../../../src/util/user";
 
 let bApp: Express;
@@ -20,6 +20,7 @@ testHubUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoY
  * Preparing for the tests
  */
 beforeAll(async (done: jest.DoneCallback): Promise<void> => {
+  initEnv();
   buildApp(async (builtApp: Express, err: Error): Promise<void> => {
     if (err) {
       throw new Error("Failed to setup test");

--- a/test/e2e/controllers/util/user/authorization.test.ts
+++ b/test/e2e/controllers/util/user/authorization.test.ts
@@ -1,11 +1,11 @@
 import { User } from "../../../../../src/db/entity/hub";
 import { buildApp } from "../../../../../src/app";
-import { getConnection, getRepository } from "typeorm";
+import { getConnection } from "typeorm";
 import * as request from "supertest";
 import { HttpResponseCode } from "../../../../../src/util/errorHandling";
 import { AuthLevels } from "../../../../../src/util/user";
 import { Express } from "express";
-import { reloadTestDatabaseConnection, closeTestDatabaseConnection, getTestDatabaseOptions } from "../../../../util/testUtils";
+import { reloadTestDatabaseConnection, closeTestDatabaseConnection, getTestDatabaseOptions, initEnv } from "../../../../util/testUtils";
 
 let bApp: Express;
 let sessionCookie: string;
@@ -20,6 +20,7 @@ testHubUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoY
  * Preparing for the tests
  */
 beforeAll(async (done: jest.DoneCallback): Promise<void> => {
+  initEnv();
   buildApp(async (builtApp: Express, err: Error): Promise<void> => {
     if (err) {
       throw new Error("Failed to setup test");

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,12 +1,18 @@
 import { Express } from "express";
 import { buildApp } from "../../src/app";
 import { getConnection } from "typeorm";
-import { getTestDatabaseOptions } from "../util/testUtils";
+import { getTestDatabaseOptions, initEnv } from "../util/testUtils";
 
 /**
  * App startup tests
  */
 describe("App startup tests", (): void => {
+  /**
+   * Setup the env variables for the tests
+   */
+  beforeAll((): void => {
+    initEnv();
+  });
   /**
    * Building app with default settings
    */

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -38,4 +38,8 @@ export function initEnv(): void {
   process.env.KEY_LENGTH = "32";
   process.env.DIGEST = "sha256";
   process.env.ENABLE_LOGGING = "0";
+  process.env.SESSION_SECRET = "cat";
+  process.env.HARDWARE_LOG_FILE_NAME = "hub.hardware.test.log";
+  process.env.HUB_LOG_FILE_NAME = "hub.test.log";
+  process.env.ENVIRONMENT = "dev";
 }


### PR DESCRIPTION
For issue #120 

Changes:
- Added more settings to the `initEnv()` function in the test utils, for session secret and file names
- Controllers now only use the test env settings