### PR TITLE
Teams can have unique names

### DIFF
--- a/src/controllers/hardwareController.ts
+++ b/src/controllers/hardwareController.ts
@@ -170,7 +170,8 @@ export class HardwareController {
     // otherwise, return that the item can't be reserved
     try {
       // First check that the team table number is set
-      if (!(await this.teamService.checkTeamTableIsSet(req.user.team)))
+      // Check if the team is undefined, use == instead of === since typeorm returns null for relations that are not defined
+      if (req.user.team == undefined || !(await this.teamService.checkTeamTableIsSet(req.user.team.teamCode)))
         return next(new ApiError(HttpResponseCode.BAD_REQUEST, "You need to create a team and set your table number in the profile page first."));
 
       const { item, quantity } = req.body;
@@ -180,7 +181,7 @@ export class HardwareController {
       const token: string = await this.hardwareService.reserveItem(req.user, item, quantity);
       if (token) {
         res.send({
-          "message": "Item(s) reserved!",
+          "message": `Item${quantity > 1 ? "(s)" : ""} reserved!`,
           "token": token,
           "quantity": quantity || 1
         });

--- a/src/controllers/teamController.ts
+++ b/src/controllers/teamController.ts
@@ -2,7 +2,7 @@ import * as crypto from "crypto";
 
 import { Request, Response } from "express";
 import { ApiError, HttpResponseCode } from "../util/errorHandling";
-import { User } from "../db/entity/hub";
+import { User, Team } from "../db/entity/hub";
 import { NextFunction } from "connect";
 import { TeamService } from "../services/teams";
 import { UserService } from "../services/users";
@@ -19,25 +19,12 @@ export class TeamController {
   }
 
   /**
-   * Adds the user to a team using the team code
-   */
-  public add = async (req: Request, res: Response, next: Function): Promise<void> => {
-    const teamCode: string = req.body.teamcode;
-
-    if (teamCode && await this.teamService.joinTeam(req.user.id, teamCode))
-      res.send({"teamcode": req.body.teamcode});
-    else
-      return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Invalid team code"));
-  };
-
-  /**
    * Creates a new team, returning a custom team code
    */
   public create = async (req: Request, res: Response, next: Function): Promise<void> => {
-    // Create a cryptographically strong random hex string of length 13
-    const newTeamCode: string = crypto.randomBytes(Math.ceil(13 / 2)).toString("hex").slice(0, 13);
-    if (await this.teamService.createTeam(newTeamCode)) {
-      if (await this.teamService.joinTeam(req.user.id, newTeamCode)) {
+    const createdTeam: Team = await this.teamService.createTeam();
+    if (createdTeam) {
+      if (await this.teamService.joinTeam(req.user.id, createdTeam.teamCode)) {
         res.send("Created new team");
         return;
       }
@@ -57,10 +44,10 @@ export class TeamController {
   };
 
   /**
-   * Leaves the users current team
+   * Joins the team specified by the teamcode
    */
   public join = async (req: Request, res: Response, next: Function): Promise<void> => {
-    if (await this.teamService.joinTeam(req.user.id, req.body.team)) {
+    if (req.body.hasOwnProperty("team") && await this.teamService.joinTeam(req.user.id, req.body.team)) {
       res.send("Joined team successfully.");
       return;
     }
@@ -76,10 +63,10 @@ export class TeamController {
     const teams: Map<string, Object[]> = new Map<string, Object[]>();
 
     allUserTeams.forEach((user: User) => {
-      if (!teams.has(user.team))
-        teams.set(user.team, []);
+      if (!teams.has(user.team.teamCode))
+        teams.set(user.team.teamCode, []);
 
-      teams.get(user.team).push({
+      teams.get(user.team.teamCode).push({
         "name": user.name,
         "email": user.email
       });
@@ -122,7 +109,7 @@ export class TeamController {
   };
 
   public updateTable = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    if (!req.user.team) return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Team not found"));
+    if (!req.user.team || !req.body.tableNumber) return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Failed to update the team table number."));
 
     if (await this.teamService.updateTeamTableNumber(req.user.team, req.body.tableNumber))
       res.send("Updated the teams table number!");

--- a/src/controllers/teamController.ts
+++ b/src/controllers/teamController.ts
@@ -116,4 +116,13 @@ export class TeamController {
     else
       return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Failed to update the team table number."));
   };
+
+  public updateName = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    if (!req.user.team) return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Team not found"));
+
+    if (await this.teamService.updateTeamName(req.user.team, req.body.name))
+      res.send("Updated the teams name!");
+    else
+      return next(new ApiError(HttpResponseCode.BAD_REQUEST, "Team name may already be taken"));
+  };
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -75,8 +75,8 @@ export class UserController {
     let teamEntity: Team = undefined;
 
     if (profile.team) {
-      userTeam = await this.teamService.getUsersTeamMembers(profile.team);
-      teamEntity = await this.teamService.getUsersTeam(profile.team);
+      userTeam = await this.teamService.getUsersTeamMembers(profile.team.teamCode);
+      teamEntity = await this.teamService.getTeam(profile.team.teamCode);
     }
 
     const teamMembers: Array<Object> = [];

--- a/src/db/entity/hub/team.ts
+++ b/src/db/entity/hub/team.ts
@@ -12,6 +12,9 @@ export class Team {
   @Column({ nullable: true })
   tableNumber: number;
 
+  @Column({ unique: true, nullable: true })
+  name: string;
+
   @OneToMany(() => User, user => user.team)
   users: User[];
 }

--- a/src/db/entity/hub/team.ts
+++ b/src/db/entity/hub/team.ts
@@ -1,8 +1,9 @@
-import { Entity, Column, PrimaryColumn } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToOne } from "typeorm";
+import { User } from ".";
 
 @Entity()
 export class Team {
-  @PrimaryColumn("varchar", { length: 13 })
+  @PrimaryGeneratedColumn("uuid")
   teamCode: string;
 
   @Column({ nullable: true })
@@ -10,4 +11,7 @@ export class Team {
 
   @Column({ nullable: true })
   tableNumber: number;
+
+  @OneToMany(() => User, user => user.team)
+  users: User[];
 }

--- a/src/db/entity/hub/user.ts
+++ b/src/db/entity/hub/user.ts
@@ -1,6 +1,7 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from "typeorm";
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, OneToOne, JoinColumn, ManyToOne } from "typeorm";
 import { AchievementProgress } from "./achievementProgress";
 import { ReservedHardwareItem } from "./reservedHardwareItem";
+import { Team } from "./";
 
 /**
  * A class to store the user entity in the database
@@ -22,8 +23,11 @@ export class User {
   @Column()
   authLevel: number;
 
-  @Column("varchar", { length: 13, nullable: true })
-  team: string;
+  /**
+   * Each user can only be in one team at a time, they are allowed to be in no team
+   */
+  @ManyToOne(() => Team, team => team.users, { nullable: true })
+  team: Team;
 
   @Column("simple-array", { nullable: true })
   push_id: string[];

--- a/src/public/js/profile.js
+++ b/src/public/js/profile.js
@@ -54,6 +54,22 @@ function createTeam() {
   });
 }
 
+function updateName(newName) {
+  $.post({
+    url: "/team/updateTeamName",
+    data: {
+      name: newName
+    },
+    success: function(response) {
+      location.reload();
+    },
+    error: function(error) {
+      showError(error.responseJSON.message);
+      return;
+    }
+  });
+}
+
 function joinTeam(teamCode) {
   $.post({
     url: "/team/join",

--- a/src/routes/teamRouter.ts
+++ b/src/routes/teamRouter.ts
@@ -19,11 +19,6 @@ export const teamRouter = (): Router => {
   const teamController = new TeamController(teamService, userService);
 
   /**
-   * POST /team/add
-   */
-  router.post("/add", checkIsLoggedIn, teamController.add);
-
-  /**
    * POST /team/create
    */
   router.post("/create", checkIsLoggedIn, teamController.create);

--- a/src/routes/teamRouter.ts
+++ b/src/routes/teamRouter.ts
@@ -53,5 +53,10 @@ export const teamRouter = (): Router => {
    */
   router.post("/updateTableNumber", checkIsLoggedIn, teamController.updateTable);
 
+  /**
+   * POST /team/updateTeamName
+   */
+  router.post("/updateTeamName", checkIsLoggedIn, teamController.updateName);
+
   return router;
 };

--- a/src/services/teams/teamService.ts
+++ b/src/services/teams/teamService.ts
@@ -1,7 +1,6 @@
 import { Repository } from "typeorm";
 import { Team, User } from "../../db/entity/hub";
 import { UserService } from "../users";
-import { ApiError, HttpResponseCode } from "../../util/errorHandling";
 
 export class TeamService {
   private teamRepository: Repository<Team>;

--- a/src/services/teams/teamService.ts
+++ b/src/services/teams/teamService.ts
@@ -115,7 +115,7 @@ export class TeamService {
    */
   public updateTeamName = async (teamCode: string, newTeamName: string): Promise<boolean> => {
     const foundTeam: Team = await this.getTeam(teamCode);
-    if (!foundTeam) return false;
+    if (foundTeam === undefined) return false;
 
     try {
       foundTeam.name = newTeamName;

--- a/src/services/teams/teamService.ts
+++ b/src/services/teams/teamService.ts
@@ -109,6 +109,24 @@ export class TeamService {
   };
 
   /**
+   * Updates the team name
+   * @param teamCode
+   * @param newTeamName
+   */
+  public updateTeamName = async (teamCode: string, newTeamName: string): Promise<boolean> => {
+    const foundTeam: Team = await this.getTeam(teamCode);
+    if (!foundTeam) return false;
+
+    try {
+      foundTeam.name = newTeamName;
+      await this.teamRepository.save(foundTeam);
+    } catch (err) {
+      return false;
+    }
+    return true;
+  };
+
+  /**
    * Checks that the team exists given a team code
    * @param teamCode The team code to check that the team exists
    * @returns true if the team exists, false otherwise
@@ -129,8 +147,12 @@ export class TeamService {
    */
   public getTeam = async (teamCode: string): Promise<Team> => {
     try {
-      return await this.teamRepository
-        .findOne(teamCode);
+      let team: Team = await this.teamRepository.findOne(teamCode);
+      // The given code wasn't found as an id, check if its the team name
+      if (team === undefined)
+        team = await this.teamRepository.findOne({ name: teamCode });
+
+      return team;
     } catch (err) {
       throw new Error(`Lost connection to database (hub)! ${err}`);
     }

--- a/src/services/teams/teamService.ts
+++ b/src/services/teams/teamService.ts
@@ -67,7 +67,7 @@ export class TeamService {
       await this.userService.setUserTeam(userID, teamToJoin);
       return true;
     } catch (err) {
-      throw new ApiError(HttpResponseCode.INTERNAL_ERROR, "Failed to update the users team");
+      return false;
     }
   };
 

--- a/src/services/users/userService.ts
+++ b/src/services/users/userService.ts
@@ -181,11 +181,10 @@ export class UserService {
    * @param newTeam The new team for the user
    */
   public setUserTeam = async (userID: number, newTeam: Team): Promise<void> => {
-    try {
-      // Updates and sets the team for the specified user
-      const user: User = await this.getUserByIDFromHub(userID);
-      if (!user) throw new ApiError(HttpResponseCode.BAD_REQUEST, "Failed to find the user with id");
+    // Updates and sets the team for the specified user
+    const user: User = await this.getUserByIDFromHub(userID);
 
+    try {
       // Set the new team and update the user
       user.team = newTeam;
       await this.userRepository.save(user);

--- a/src/services/users/userService.ts
+++ b/src/services/users/userService.ts
@@ -181,6 +181,8 @@ export class UserService {
    * @param newTeam The new team for the user
    */
   public setUserTeam = async (userID: number, newTeam: Team): Promise<void> => {
+    if (userID === undefined || newTeam === undefined) throw new Error("Failed to update team.");
+
     // Updates and sets the team for the specified user
     const user: User = await this.getUserByIDFromHub(userID);
 

--- a/src/views/pages/profile.ejs
+++ b/src/views/pages/profile.ejs
@@ -64,7 +64,7 @@
                   <h4 class="card-title">Team Information</h4>
                 </div>
                 <div class="card-body">
-                  <h2 class="text-center">Team code: <%= user.team %></h2>
+                  <h2 class="text-center text">Team code: <%= user.team.teamCode %></h2>
                   <div class="form-group">
                     <div id="teamMemberList">
                       <h3>Team members</h3>

--- a/src/views/pages/profile.ejs
+++ b/src/views/pages/profile.ejs
@@ -24,6 +24,21 @@
                   <h2><%= user.name %></h2>
                   <h3 id="emailText"><%= user.email %></h3>
                 </div>
+
+                <% if (user.team) { %>
+                <div class="card-body">
+                  <div class="form-group">
+                    <label for="teamName">Team Name </label>
+                    <% if (restrict) { %>
+                    <input type="text" class="form-control" id="teamName" placeholder="Hackathon Team" value="<%= teamEntity.name %>" disabled>
+                    <% } else { %>
+                    <input type="text" class="form-control" id="teamName" placeholder="Hackathon Team" value="<%= teamEntity.name %>">
+                    <button class="btn btn-success" onclick="updateName($('#teamName').val())">Save</button>
+                    <% } %>
+                  </div>
+                </div>
+                <% } %>
+
                 <% if (user.team) { %>
                 <div class="card-body">
                   <div class="form-group">
@@ -37,6 +52,7 @@
                   </div>
                 </div>
                 <% } %>
+
                 <div class="card-body">
                   <div class="form-group">
                     <% if (restrict && user.team) { %>
@@ -64,7 +80,11 @@
                   <h4 class="card-title">Team Information</h4>
                 </div>
                 <div class="card-body">
-                  <h2 class="text-center text">Team code: <%= user.team.teamCode %></h2>
+                  <% if (user.team.name) { %>
+                    <h2 class="text-center text">Team name: <%= user.team.name %></h2>
+                  <% } else { %>
+                    <h2 class="text-center text">Team code: <%= user.team.teamCode %></h2> 
+                  <% } %>
                   <div class="form-group">
                     <div id="teamMemberList">
                       <h3>Team members</h3>
@@ -96,7 +116,7 @@
                 </div>
                 <div class="card-body">
                   <div class="form-group">
-                    <label for="teamCodeInput">Team code</label>
+                    <label for="teamCodeInput">Team name or code</label>
                     <input type="text" class="form-control" id="teamCodeInput" placeholder="aWeRsOmEtEaM">
                     <button class="btn btn-success" onclick="joinTeam($('#teamCodeInput').val())">Join team</button>
                   </div>

--- a/test/e2e/controllers/hardwareController.test.ts
+++ b/test/e2e/controllers/hardwareController.test.ts
@@ -4,21 +4,18 @@ import { User, HardwareItem, ReservedHardwareItem, Team } from "../../../src/db/
 import { getConnection } from "typeorm";
 import * as request from "supertest";
 import { HttpResponseCode } from "../../../src/util/errorHandling/httpResponseCode";
-import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection } from "../../util/testUtils";
+import { getTestDatabaseOptions, reloadTestDatabaseConnection, closeTestDatabaseConnection, initEnv } from "../../util/testUtils";
 import { AuthLevels } from "../../../src/util/user";
 
 let bApp: Express;
 let sessionCookie: string;
 let userReservationToken: string;
 
-const testHubTeamCode: string = "qwerty";
-
 const testAttendeeUser: User = new User();
 testAttendeeUser.name = "Billy Tester II";
 testAttendeeUser.email = "billyII@testing.com";
 testAttendeeUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
 testAttendeeUser.authLevel = AuthLevels.Attendee;
-testAttendeeUser.team = testHubTeamCode;
 
 const piHardwareItem: HardwareItem = new HardwareItem();
 piHardwareItem.name = "Pi";
@@ -35,8 +32,7 @@ viveHardwareItem.takenStock = 0;
 viveHardwareItem.itemURL = "";
 
 const testHubTeam: Team = new Team();
-testHubTeam.teamCode = testHubTeamCode;
-testHubTeam.tableNumber = 42;
+testHubTeam.tableNumber = 10;
 
 const itemReservation: ReservedHardwareItem = new ReservedHardwareItem();
 itemReservation.reservationToken = "token";
@@ -60,20 +56,6 @@ beforeAll(async (done: jest.DoneCallback): Promise<void> => {
 
 beforeEach(async (done: jest.DoneCallback): Promise<void> => {
   await reloadTestDatabaseConnection("hub");
-
-  // Setup the data for the test
-  await getConnection("hub").getRepository(User).save(testAttendeeUser);
-  await getConnection("hub").getRepository(HardwareItem).save(piHardwareItem);
-  await getConnection("hub").getRepository(HardwareItem).save(viveHardwareItem);
-  await getConnection("hub").getRepository(Team).save(testHubTeam);
-
-  const response = await request(bApp)
-    .post("/user/login")
-    .send({
-      email: testAttendeeUser.email,
-      password: "password123"
-    });
-  sessionCookie = response.header["set-cookie"].pop().split(";")[0];
   done();
 });
 
@@ -81,7 +63,22 @@ beforeEach(async (done: jest.DoneCallback): Promise<void> => {
 /**
  * Testing hardware library requests
  */
-describe("Hardware controller tests", (): void => {
+describe("Hardware controller tests, user not in team", (): void => {
+  beforeEach(async (done: jest.DoneCallback): Promise<void> => {
+    // Setup the data for the test
+    await getConnection("hub").getRepository(User).save(testAttendeeUser);
+    await getConnection("hub").getRepository(HardwareItem).save(piHardwareItem);
+    await getConnection("hub").getRepository(HardwareItem).save(viveHardwareItem);
+    const response = await request(bApp)
+      .post("/user/login")
+      .send({
+        email: testAttendeeUser.email,
+        password: "password123"
+      });
+    sessionCookie = response.header["set-cookie"].pop().split(";")[0];
+    done();
+  });
+
   /**
    * Test that the take item route is protected
    */
@@ -97,49 +94,9 @@ describe("Hardware controller tests", (): void => {
   });
 
   /**
-   * Test that an item is reserved when a user sends a request
-   */
-  test("Should check the specified item is reserved by the user", async (): Promise<void> => {
-    const response = await request(bApp)
-      .post("/hardware/reserve")
-      .set("Cookie", sessionCookie)
-      .send({
-        item: piHardwareItem.id,
-        quantity: 1
-      });
-
-    expect(response.status).toBe(HttpResponseCode.OK);
-    expect(response.body.message).toBe("Item(s) reserved!");
-    expect(response.body.token).toBeDefined();
-    userReservationToken = response.body.token;
-
-    // Test that once item is reserved, reservation is added to database
-    const reservation: ReservedHardwareItem = await getConnection("hub")
-      .getRepository(ReservedHardwareItem)
-      .createQueryBuilder("item")
-      .where("item.userId = :id", { id: testAttendeeUser.id })
-      .andWhere("item.hardwareItemId = :itemID", { itemID: piHardwareItem.id })
-      .getOne();
-    expect(reservation).toBeDefined();
-    expect(reservation.isReserved).toBe(true);
-    expect(reservation.reservationQuantity).toBe(1);
-
-    const updatedHardwareItem: HardwareItem = await getConnection("hub")
-      .getRepository(HardwareItem)
-      .findOne(piHardwareItem.id);
-    expect(updatedHardwareItem.reservedStock).toBe(1);
-  });
-
-  /**
    * Test if a user can reserve if not in a team
    */
   test("Should check that reservation is rejected when user not in a team", async (): Promise<void> => {
-    // Remove the team from the user
-    testAttendeeUser.team = "";
-    await getConnection("hub")
-      .getRepository(User)
-      .save(testAttendeeUser);
-
     const response = await request(bApp)
     .post("/hardware/reserve")
     .set("Cookie", sessionCookie)
@@ -150,11 +107,6 @@ describe("Hardware controller tests", (): void => {
 
     expect(response.status).toBe(HttpResponseCode.BAD_REQUEST);
     expect(response.body.message).toBe("You need to create a team and set your table number in the profile page first.");
-
-    testAttendeeUser.team = testHubTeamCode;
-    await getConnection("hub")
-      .getRepository(User)
-      .save(testAttendeeUser);
   });
 
   /**
@@ -207,6 +159,62 @@ describe("Hardware controller tests", (): void => {
       expect(response).toBeDefined();
       expect(response.body.message).toBe("Item has been returned to the library");
     });
+  });
+});
+
+/**
+ * Testing hardware library requests, user not in team
+ */
+describe("Hardware controller tests, user in team", (): void => {
+  beforeEach(async (done: jest.DoneCallback): Promise<void> => {
+    // Setup the data for the test
+    await getConnection("hub").getRepository(Team).save(testHubTeam);
+    testAttendeeUser.team = testHubTeam;
+    await getConnection("hub").getRepository(User).save(testAttendeeUser);
+    await getConnection("hub").getRepository(HardwareItem).save(piHardwareItem);
+    await getConnection("hub").getRepository(HardwareItem).save(viveHardwareItem);
+    const response = await request(bApp)
+      .post("/user/login")
+      .send({
+        email: testAttendeeUser.email,
+        password: "password123"
+      });
+    sessionCookie = response.header["set-cookie"].pop().split(";")[0];
+    done();
+  });
+
+  /**
+   * Test that an item is reserved when a user sends a request
+   */
+  test("Should check the specified item is reserved by the user", async (): Promise<void> => {
+    const response = await request(bApp)
+      .post("/hardware/reserve")
+      .set("Cookie", sessionCookie)
+      .send({
+        item: piHardwareItem.id,
+        quantity: 1
+      });
+
+    expect(response.status).toBe(HttpResponseCode.OK);
+    expect(response.body.message).toBe("Item reserved!");
+    expect(response.body.token).toBeDefined();
+    userReservationToken = response.body.token;
+
+    // Test that once item is reserved, reservation is added to database
+    const reservation: ReservedHardwareItem = await getConnection("hub")
+      .getRepository(ReservedHardwareItem)
+      .createQueryBuilder("item")
+      .where("item.userId = :id", { id: testAttendeeUser.id })
+      .andWhere("item.hardwareItemId = :itemID", { itemID: piHardwareItem.id })
+      .getOne();
+    expect(reservation).toBeDefined();
+    expect(reservation.isReserved).toBe(true);
+    expect(reservation.reservationQuantity).toBe(1);
+
+    const updatedHardwareItem: HardwareItem = await getConnection("hub")
+      .getRepository(HardwareItem)
+      .findOne(piHardwareItem.id);
+    expect(updatedHardwareItem.reservedStock).toBe(1);
   });
 });
 

--- a/test/unit/services/hardwareService.test.ts
+++ b/test/unit/services/hardwareService.test.ts
@@ -1,7 +1,7 @@
 import { HardwareService, ReservedHardwareService } from "../../../src/services/hardware";
 import { createTestDatabaseConnection, closeTestDatabaseConnection, reloadTestDatabaseConnection, initEnv } from "../../util/testUtils";
 import { getRepository, Repository } from "typeorm";
-import { User, AchievementProgress, ReservedHardwareItem, HardwareItem } from "../../../src/db/entity/hub";
+import { User, AchievementProgress, ReservedHardwareItem, HardwareItem, Team } from "../../../src/db/entity/hub";
 import { HttpResponseCode } from "../../../src/util/errorHandling";
 
 const piHardwareItem: HardwareItem = new HardwareItem();
@@ -23,7 +23,6 @@ testUser.name = "Billy Tester II";
 testUser.email = "billyII@testing-validation.com";
 testUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
 testUser.authLevel = 1;
-testUser.team = "TeamCodeHere-";
 testUser.push_id = ["a64a87ad-df62-47c7-9592-85d71291abf2"];
 
 const itemReservation: ReservedHardwareItem = new ReservedHardwareItem();
@@ -38,7 +37,7 @@ let reservedHardwareService: ReservedHardwareService;
 beforeAll(async (done: jest.DoneCallback): Promise<void> => {
   initEnv();
 
-  await createTestDatabaseConnection([ User, AchievementProgress, ReservedHardwareItem, HardwareItem ]);
+  await createTestDatabaseConnection([ User, Team, AchievementProgress, ReservedHardwareItem, HardwareItem ]);
   reservedHardwareService = new ReservedHardwareService(getRepository(ReservedHardwareItem));
   hardwareService = new HardwareService(getRepository(HardwareItem), reservedHardwareService);
 

--- a/test/unit/services/reservedHardwareService.test.ts
+++ b/test/unit/services/reservedHardwareService.test.ts
@@ -1,7 +1,7 @@
 import { HardwareService, ReservedHardwareService } from "../../../src/services/hardware";
 import { createTestDatabaseConnection, closeTestDatabaseConnection, reloadTestDatabaseConnection, initEnv } from "../../util/testUtils";
 import { getRepository, Repository } from "typeorm";
-import { User, AchievementProgress, ReservedHardwareItem, HardwareItem } from "../../../src/db/entity/hub";
+import { User, AchievementProgress, ReservedHardwareItem, HardwareItem, Team } from "../../../src/db/entity/hub";
 import { HttpResponseCode } from "../../../src/util/errorHandling";
 
 const piHardwareItem: HardwareItem = new HardwareItem();
@@ -23,7 +23,6 @@ testUser.name = "Billy Tester II";
 testUser.email = "billyII@testing-validation.com";
 testUser.password = "pbkdf2_sha256$30000$xmAiV8Wihzn5$BBVJrxmsVASkYuOI6XdIZoYLfy386hdMOF8S14WRTi8=";
 testUser.authLevel = 1;
-testUser.team = "TeamCodeHere-";
 testUser.push_id = ["a64a87ad-df62-47c7-9592-85d71291abf2"];
 
 const itemReservation: ReservedHardwareItem = new ReservedHardwareItem();
@@ -37,7 +36,7 @@ let reservedHardwareService: ReservedHardwareService;
 beforeAll(async (done: jest.DoneCallback): Promise<void> => {
   initEnv();
 
-  await createTestDatabaseConnection([ User, AchievementProgress, ReservedHardwareItem, HardwareItem ]);
+  await createTestDatabaseConnection([ User, Team, AchievementProgress, ReservedHardwareItem, HardwareItem ]);
   reservedHardwareService = new ReservedHardwareService(getRepository(ReservedHardwareItem));
 
   done();

--- a/test/unit/services/teamService.test.ts
+++ b/test/unit/services/teamService.test.ts
@@ -190,6 +190,32 @@ describe("Team service tests", (): void => {
   });
 
   /**
+   * Test if a teams name can be updated
+   */
+  describe("Test updateTeamName", (): void => {
+    test("Should ensure that a teams name can be updated", async (): Promise<void> => {
+      const teamRepository: Repository<Team> = getRepository(Team);
+      const newName: string = "test1";
+
+      const result: boolean = await teamService.updateTeamName(testHubTeam.teamCode, newName);
+      expect(result).toBeTruthy();
+
+      const updatedTeam: Team = await teamRepository.findOne({ name: newName });
+      expect(updatedTeam.name).toEqual(newName);
+    });
+    test("Should ensure that a team name not updated when invalid", async (): Promise<void> => {
+      // Test setup
+      const teamRepository: Repository<Team> = getRepository(Team);
+      const testTeam: Team = {...testHubTeam, teamCode: "id1", name: "test"};
+      await teamRepository.save(testTeam);
+
+      // Run the test
+      const result: boolean = await teamService.updateTeamName(testHubUser.team.teamCode, "test");
+      expect(result).toBeFalsy();
+    });
+  });
+
+  /**
    * Test that a users team members function works
    */
   describe("Test getUsersTeamMembers", (): void => {

--- a/test/unit/services/teamService.test.ts
+++ b/test/unit/services/teamService.test.ts
@@ -210,8 +210,19 @@ describe("Team service tests", (): void => {
       await teamRepository.save(testTeam);
 
       // Run the test
-      const result: boolean = await teamService.updateTeamName(testHubUser.team.teamCode, "test");
-      expect(result).toBeFalsy();
+      const resultWhenTeamValid: boolean = await teamService.updateTeamName(testHubUser.team.teamCode, "test");
+      expect(resultWhenTeamValid).toBeFalsy();
+
+      const resultWhenNoTeam: boolean = await teamService.updateTeamName("abcdef", "test");
+      expect(resultWhenNoTeam).toBeFalsy();
+    });
+    test("Should ensure that a team name not updated when team not found", async (): Promise<void> => {
+      // Test setup
+      const teamRepository: Repository<Team> = getRepository(Team);
+      const testTeam: Team = {...testHubTeam, teamCode: "id1", name: "test"};
+
+      // Run the test
+
     });
   });
 

--- a/test/unit/services/userService.test.ts
+++ b/test/unit/services/userService.test.ts
@@ -234,7 +234,7 @@ describe("User service tests", (): void => {
       try {
         await userService.setUserTeam(100, undefined);
       } catch (err) {
-        expect(err.statusCode).toBe(HttpResponseCode.BAD_REQUEST);
+        expect(err.message).toBe("Failed to update team.");
       }
     });
   });


### PR DESCRIPTION
For issues #119 and #118 

This pull request add the ability for teams to create a custom name for their team. When a team is created a UUID is created by default. Then the members have the option of changing the team name.

Along with this, a team can be joined by either the team code (uuid) or the custom team name.